### PR TITLE
Fix $scope on form edit

### DIFF
--- a/src/controllers/FormController.js
+++ b/src/controllers/FormController.js
@@ -75,6 +75,9 @@ angular.module('ngFormBuilderHelper')
       if (!$scope.form.name || $scope.form.name === _.camelCase(oldTitle)) {
         $scope.form.name = _.camelCase($scope.form.title);
       }
+      if ($scope.$parent && $scope.$parent.form) {
+        $scope.$parent.form.title = $scope.form.title;
+      }
     };
 
     // When a submission is made.

--- a/src/providers/FormioFormBuilder.js
+++ b/src/providers/FormioFormBuilder.js
@@ -66,7 +66,7 @@ angular.module('ngFormBuilderHelper')
             url: '/edit',
             ncyBreadcrumb: {skip: true},
             templateUrl: _.get(templates, 'form.edit', 'formio-helper/formbuilder/edit.html'),
-            controller: ['$scope', '$controller', execute('form.edit')]
+            controller: ['$scope', '$controller', 'FormController', execute('form.edit')]
           })
           .state(basePath + 'form.delete', {
             url: '/delete',


### PR DESCRIPTION
Add FormController directly in the Edit Form because after an edit of a form, the next edit will create a new FormController.

To reproduce : 
- Edit a form -> Save -> edit again without refresh -> Save
- Or Edit a form -> Save -> edit title and the title above the tabs is not updated due to the differents scopes.