### PR TITLE
Refresh project and access when user logs in

### DIFF
--- a/src/providers/FormioAuth.js
+++ b/src/providers/FormioAuth.js
@@ -59,7 +59,7 @@ angular.module('ngFormioHelper')
                   return;
                 }
 
-                $q.all([$rootScope.projectPromise, $rootScope.accessPromise]).then(function() {
+                $q.all([$rootScope.projectRequest(), $rootScope.accessRequest()]).then(function() {
                   $rootScope.setUser(submission, resource);
                   $state.go(authState);
                 });
@@ -89,29 +89,35 @@ angular.module('ngFormioHelper')
               init = true;
 
               // Load the project.
-              $rootScope.projectPromise = Formio.makeStaticRequest(Formio.getAppUrl()).then(function(project) {
-                angular.forEach(project.access, function(access) {
-                  formAccess[access.type] = access.roles;
+              $rootScope.projectRequest = function () {
+                return Formio.makeStaticRequest(Formio.getAppUrl()).then(function(project) {
+                  angular.forEach(project.access, function(access) {
+                    formAccess[access.type] = access.roles;
+                  });
+                }, function(err) {
+                  formAccess = {};
+                  return null;
                 });
-              }, function(err) {
-                formAccess = {};
-                return null;
-              });
+              };
+              $rootScope.projectPromise = $rootScope.projectRequest();
 
               // Get the access for this project.
-              $rootScope.accessPromise = Formio.makeStaticRequest(Formio.getAppUrl() + '/access').then(function(access) {
-                angular.forEach(access.forms, function(form) {
-                  submissionAccess[form.name] = {};
-                  form.submissionAccess.forEach(function(access) {
-                    submissionAccess[form.name][access.type] = access.roles;
+              $rootScope.accessRequest = function () {
+                return Formio.makeStaticRequest(Formio.getAppUrl() + '/access').then(function(access) {
+                  angular.forEach(access.forms, function(form) {
+                    submissionAccess[form.name] = {};
+                    form.submissionAccess.forEach(function(access) {
+                      submissionAccess[form.name][access.type] = access.roles;
+                    });
                   });
+                  roles = access.roles;
+                  return access;
+                }, function(err) {
+                  roles = {};
+                  return null;
                 });
-                roles = access.roles;
-                return access;
-              }, function(err) {
-                roles = {};
-                return null;
-              });
+              };
+              $rootScope.accessPromise = $rootScope.accessRequest();
 
               $rootScope.user = null;
               $rootScope.isReady = false;


### PR DESCRIPTION
Call to FormioAuth.init() may fail due to session timeout.  For example user waits a long time and refreshes app or returns to it by pressing back button.  In this case the _roles_ variable will remain or be set to {}.

When the user then logs in the _roles_ variable will not be refreshed because $q.all[...] is waiting on promises which have already been fulfilled (unsuccessfully).  The code that made the promises in the first place needs to be run again.

To reproduce set server's jwt expireTime to 1 in default.json.  Run formio-app-formio.  Login and go to some form's page.  Wait a minute.  Refresh.  Session will have expired so log in again.  Go to same form.  Row of tabs will be missing because _isAdministrator_ is not set because _roles_ is empty.