### PR TITLE
Improve feedback and go to home state

### DIFF
--- a/src/controllers/FormController.js
+++ b/src/controllers/FormController.js
@@ -104,13 +104,14 @@ angular.module('ngFormBuilderHelper')
       FormioAlerts.onError(error);
     });
 
-    // Called when the form is deleted.
+    // Called when the form or resource is deleted.
     $scope.$on('delete', function() {
+      var type = $scope.form.type === 'form' ? 'Form ' : 'Resource ';
       FormioAlerts.addAlert({
         type: 'success',
-        message: 'Form was deleted.'
+        message: type + $scope.form.name + ' was deleted.'
       });
-      $state.go($scope.basePath + 'formIndex');
+      $state.go($scope.basePath + 'home');
     });
 
     $scope.$on('cancel', function() {


### PR DESCRIPTION
When a form or resource is deleted the state is transitioned to 'formIndex'.  This state is not otherwise used by formio-app-formio so causes confusion and in any app doesn't make much sense if it was a resource which has been deleted.  Just transition to 'home' state.  Also improve feedback to indicate type and name of what's been deleted.