### PR TITLE
Fixed reference issue for actionInfo settings and actions

### DIFF
--- a/src/controllers/FormActionController.js
+++ b/src/controllers/FormActionController.js
@@ -21,6 +21,7 @@ angular.module('ngFormBuilderHelper')
     $scope.action = {data: {settings: {}, condition: {}}};
     $scope.newAction = {name: '', title: 'Select an Action'};
     $scope.availableActions = {};
+    Formio.clearCache();
     $scope.addAction = function() {
       if ($scope.newAction.name) {
         $state.go($scope.basePath + 'form.action.add', {
@@ -118,7 +119,9 @@ angular.module('ngFormBuilderHelper')
         var loader = new Formio($scope.actionUrl);
         return loader.loadAction().then(function(action) {
           $scope.action = angular.copy(_.merge($scope.action, {data: action}));
-          return getActionInfo(action.name);
+          return getActionInfo(action.name).then(function(actionInfo) {
+            $scope.actionInfo.settingsForm.action = $scope.actionUrl;
+          });
         });
       }
       else {

--- a/src/controllers/FormActionController.js
+++ b/src/controllers/FormActionController.js
@@ -49,7 +49,7 @@ angular.module('ngFormBuilderHelper')
     var getActionInfo = function(name) {
       return $scope.formio.actionInfo(name).then(function(actionInfo) {
         if(actionInfo) {
-          $scope.actionInfo = _.merge($scope.actionInfo, actionInfo);
+          $scope.actionInfo = angular.copy(_.merge($scope.actionInfo, actionInfo));
           return $scope.actionInfo;
         }
       });
@@ -117,12 +117,12 @@ angular.module('ngFormBuilderHelper')
         $scope.actionUrl = $scope.formio.formUrl + '/action/' + $stateParams.actionId;
         var loader = new Formio($scope.actionUrl);
         return loader.loadAction().then(function(action) {
-          $scope.action = _.merge($scope.action, {data: action});
+          $scope.action = angular.copy(_.merge($scope.action, {data: action}));
           return getActionInfo(action.name);
         });
       }
       else {
-        $scope.action = _.merge($scope.action, {data: defaults});
+        $scope.action = angular.copy(_.merge($scope.action, {data: defaults}));
         $scope.action.data.settings = {};
         return $q.when($scope.actionInfo);
       }

--- a/src/templates/formbuilder/action/edit.html
+++ b/src/templates/formbuilder/action/edit.html
@@ -1,1 +1,1 @@
-<formio form="actionInfo.settingsForm" submission="action" form-action="actionUrl"></formio>
+<formio form="actionInfo.settingsForm" submission="action"></formio>


### PR DESCRIPTION
Fixed following,
1) Actioninfo settings not changing reference due to which action settings form not loading.
2) Clear cache onload action.
3) Setting form edit action URL update.
4) Removed form-action attr from edit action page template.
